### PR TITLE
Add verbose logging option & outFile option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 bin.js
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ sys     0m0.033s
 noderify
   -f mod                # excludes mod from the bundle
   -p prelude.js         # specify a custom prelude file (see nodepack's implementation for reference)
+  -o outfile.js         # specify the output file
+  --verbose             # turn on verbose logging
   --filter module_name1
                         # exclude this module from the bundle, use for native addons. (may be repeated)
   --replace.module_name=new-module-name

--- a/index.js
+++ b/index.js
@@ -53,6 +53,7 @@ if(!opts._[0]) {
 }
 
 var entry = opts.entry || path.resolve(opts._[0])
+var outFile = opts.o || opts.out
 
 //var replace = {}
 
@@ -72,7 +73,14 @@ require('./inject')({
   ignoreMissing: opts.ignoreMissing
 }, function (err, src) {
   if(err) throw err
-  console.log(src)
+
+  if (outFile) {
+    fs.writeFile(outFile, src, 'utf8', function (err) {
+      if (err) throw err
+    })
+  } else {
+    console.log(src)
+  }
 })
 
 

--- a/index.js
+++ b/index.js
@@ -47,6 +47,22 @@ var filter = [].concat(opts.filter)
               .concat(native_modules)
               .concat(opts.electron ? electron_modules : [])
 
+if (opts.help || opts.h) {
+  console.error(`
+noderify
+  -f mod                # excludes mod from the bundle
+  -o outfile.js         # specify the output file
+  --verbose             # turn on verbose logging
+  -p prelude.js         # specify a custom prelude file (see nodepack's implementation for reference)
+  --filter module_name1
+                        # exclude this module from the bundle, use for native addons. (may be repeated)
+  --replace.module_name=new-module-name
+                        # map one module to another.
+  `)
+  process.exit(1)
+}
+
+
 if(!opts._[0]) {
   console.error('usage: noderify entry.js > bundle.js')
   process.exit(1)

--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ var argv = require('minimist')(process.argv.slice(2), {
     e: 'electron',
     'ignore-missing': 'ignoreMissing'
   },
-  boolean: ['electron', 'version']
+  boolean: ['electron', 'version', 'verbose']
 })
 
 //startup noderify with optimist's defaults
@@ -66,6 +66,7 @@ var entry = opts.entry || path.resolve(opts._[0])
 
 require('./inject')({
   entry: entry,
+  logEnabled: opts.verbose,
   filter: filter,
   replace: opts.replace || {},
   ignoreMissing: opts.ignoreMissing

--- a/inject.js
+++ b/inject.js
@@ -77,6 +77,8 @@ function createDepStream(opts) {
       e.id = path.relative(process.cwd(), e.id)
       e.source = e.source.replace(/^\s*#![^\n]*/, '\n')
 
+      if (opts.logEnabled) console.log('Built ' + e.id + '...')
+
       try {
         JSON.parse(e.source)
         e.source = 'module.exports = ' + e.source

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
   },
   "bin": "./bin.js",
   "devDependencies": {
-    "leveldown": "^1.7.2",
-    "sodium-native": "^1.10.2"
+    "leveldown": "5.4.1",
+    "sodium-native": "2.4.6"
   },
   "scripts": {
     "prepublish": "./test/index.sh && ./index.js index.js > bin.js && npm ls",


### PR DESCRIPTION
This PR adds a verbose logging option and an `--out` file option.

This allows you to use the `noderify` tool whilst keeping a log what has been bundled

```sh
noderify index.js -f electron \
  -o build/index.js --verbose | tee build/build-main.log
```

This is super useful for auditing what dependencies you are including in the bundle and how to reduce the size of the bundle.

I also added a `--help` option for UX.

cc @staltz @dominictarr