### PR TITLE
support modern language features

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [12.x, 14.x, 18.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/index.js
+++ b/index.js
@@ -42,7 +42,8 @@ var native_modules = [
   'v8',
   'vm',
   'worker_threads',
-  'zlib'
+  'zlib',
+  'supports-color' // debug tests to see if this is present by requiring it
 ]
 
 var electron_modules = [

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "devDependencies": {
     "leveldown": "5.6.0",
+    "secret-stack": "^7.1.0",
     "sodium-native": "2.4.9"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -13,16 +13,16 @@
     "url": "git://github.com/staltz/noderify.git"
   },
   "dependencies": {
-    "minimist": "^1.1.2",
-    "module-deps": "~6.1.0",
-    "rc": "^1.1.6",
-    "resolve": "~1.7.1",
+    "minimist": "^1.2.8",
+    "module-deps": "~6.2.3",
+    "rc": "^1.2.8",
+    "resolve": "~1.22.6",
     "sort-stream": "^1.0.1",
-    "through2": "~2.0.3"
+    "through2": "~2.0.5"
   },
   "devDependencies": {
-    "leveldown": "5.4.1",
-    "sodium-native": "2.4.6"
+    "leveldown": "5.6.0",
+    "sodium-native": "2.4.9"
   },
   "scripts": {
     "prepublish": "./test/index.sh && ./index.js index.js > bin.js",

--- a/test/fbb.js
+++ b/test/fbb.js
@@ -1,4 +1,4 @@
 //test replacing foo-bar-baz
 
-console.log('test wether a replaced module actually loads submodules!')
+console.log('  ✓ replaced module loads submodules!')
 console.log(require('util').inspect(require('../package.json')))

--- a/test/index.sh
+++ b/test/index.sh
@@ -6,9 +6,9 @@
 
 was_okay () {
   if [ $? -eq 0 ]; then
-    echo Okay
+    echo "  ✓ Okay"
   else
-    echo NOT OKAY
+    echo "  ✗ NOT OKAY"
     exit 1
   fi
 }
@@ -47,53 +47,54 @@ noderify=./index.js
 #//
 #//  okay node _bundle.js
 
-echo "Test module not found error:"
+echo Test module not found error:
 not_okay $noderify test/missing.js > /dev/null
 
+echo Test self-reference:
 $noderify test/self-reference.js > _bundle.js
 was_okay
 okay node _bundle.js
 
-echo "TEST NOT FOUND, but replace missing module"
+echo Test NOT FOUND, but replace missing module:
 $noderify test/missing.js --replace.foo-bar-baz=./fbb > _bundle.js
 was_okay
 okay node _bundle.js
 
+echo Test module requirement:
 $noderify test/mod-req.js > _bundle.js
 was_okay
 okay node _bundle.js
 
+echo Test native module filtering:
 $noderify test/native.js --filter sodium-native --filter leveldown > _bundle.js
 was_okay
 okay node _bundle.js
 
-echo "replace another way"
+echo Test replace another way:
 $noderify test/native.js --no-replace.sodium-native --no-replace.leveldown > _bundle.js
 was_okay
 okay node _bundle.js
 
+echo Test new JS:
+$noderify test/new-js.js > _bundle.js
+was_okay
+okay node _bundle.js
 
 #done
 
 #set -e # exit with an error if any command fails
 
-echo noderify noderify
+echo Test noderify noderify:
 echo noderify $noderify > _b.js
 time $noderify $noderify > _b.js
 
-echo noderify noderify with the noderified noderify
+echo Test noderify noderify with the noderified noderify:
 time node _b.js $noderify > _b2.js
-
 shasum _b.js _b2.js
-
 okay diff _b.js _b2.js
-
 not_okay node _b.js missing.js  2> /dev/null > /dev/null
+
 echo "ignore missing"
 okay node _b.js missing.js --ignore-missing 2> /dev/null > /dev/null
 
 tidy
-
-
-
-

--- a/test/index.sh
+++ b/test/index.sh
@@ -6,9 +6,9 @@
 
 was_okay () {
   if [ $? -eq 0 ]; then
-    echo "  ✓ Okay"
+    echo "  \033[0;32m✓ OK\033[0m"
   else
-    echo "  ✗ NOT OKAY"
+    echo "  \033[0;31m✗ NOT OK\033[0m"
     exit 1
   fi
 }
@@ -47,16 +47,16 @@ noderify=./index.js
 #//
 #//  okay node _bundle.js
 
-echo Test module not found error:
+echo Test NOT FOUND found error:
 not_okay $noderify test/missing.js > /dev/null
-
-echo Test self-reference:
-$noderify test/self-reference.js > _bundle.js
-was_okay
-okay node _bundle.js
 
 echo Test NOT FOUND, but replace missing module:
 $noderify test/missing.js --replace.foo-bar-baz=./fbb > _bundle.js
+was_okay
+okay node _bundle.js
+
+echo Test self-reference:
+$noderify test/self-reference.js > _bundle.js
 was_okay
 okay node _bundle.js
 

--- a/test/mod-req.js
+++ b/test/mod-req.js
@@ -1,2 +1,4 @@
 var assert = module.require('assert')
 assert.strictEqual(1 + 3, 4)
+
+const newJS = require('./new-js')

--- a/test/mod-req.js
+++ b/test/mod-req.js
@@ -1,4 +1,5 @@
 var assert = module.require('assert')
 assert.strictEqual(1 + 3, 4)
 
+const stack = require('secret-stack')
 const newJS = require('./new-js')

--- a/test/new-js.js
+++ b/test/new-js.js
@@ -1,5 +1,5 @@
 
-const opts = { }
+const opts = {}
 // Node 14
 const undef = opts?.timeout // Optional chaining
 

--- a/test/new-js.js
+++ b/test/new-js.js
@@ -1,0 +1,12 @@
+
+const opts = { }
+// Node 14
+const undef = opts?.timeout // Optional chaining
+
+// Node 15
+const ten = opts.timeout ??= 10 // Nullish coalescing assignment 
+
+// Node 18
+const arr = [1, 2, 3, 4, 5]
+const four = arr.findLast(el => el % 2 === 0)
+// => 4


### PR DESCRIPTION
Trying to `noderify` `secret-stack@7` we get errors from `acorn` trying to parse `??=`, `??`,  `cb?.()`, `opts?.timeout` etc

I've looked through the stack for the best solution and tried:
- :x: set `ecmaVersion: 2023`. supposedly supported by the version of `acorn` we're using, but nope
- :heavy_check_mark: mutated the `detect` function to "tidy" the new features into version which don't break the parser

I also tidied logging to make it easier to see at a glance if things are passing